### PR TITLE
Add widget connect params

### DIFF
--- a/client/connect.go
+++ b/client/connect.go
@@ -26,13 +26,18 @@ func parseConnectResponse(response *http.Response) (*models.Connect, error) {
 	return nil, makeGenericError(response.StatusCode, bufferStr)
 }
 
-func (c *Client) GetWidget(userGuid string) (*models.Connect, error) {
+func (c *Client) GetWidget(userGuid string, params models.ConnectParams) (*models.Connect, error) {
 	if userGuid == "" {
 		return nil, MissingGuid
 	}
 
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/connect_widget_url"
-	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, string(paramsJSON), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/connect.go
+++ b/client/connect.go
@@ -26,7 +26,11 @@ func parseConnectResponse(response *http.Response) (*models.Connect, error) {
 	return nil, makeGenericError(response.StatusCode, bufferStr)
 }
 
-func (c *Client) GetWidget(userGuid string, params models.ConnectParams) (*models.Connect, error) {
+func (c *Client) GetWidget(userGuid string) (*models.Connect, error) {
+	return c.GetWidgetWithConnectParams(userGuid, models.ConnectParams{})
+}
+
+func (c *Client) GetWidgetWithConnectParams(userGuid string, params models.ConnectParams) (*models.Connect, error) {
 	if userGuid == "" {
 		return nil, MissingGuid
 	}

--- a/models/connect.go
+++ b/models/connect.go
@@ -8,3 +8,10 @@ type Connect struct {
 type ConnectResponse struct {
 	Connect *Connect `json:"user,omitempty"`
 }
+
+type ConnectParams struct {
+	IsMobileWebView        bool    `json:"is_mobile_webview"`
+	UpdateCredentials      bool    `json:"update_credentials"`
+	CurrentInstitutionCode *string `json:"current_institution_code"`
+	CurrentMemberGuid      *string `json:"current_member_guid"`
+}


### PR DESCRIPTION
The current go client doesn't allow for posting configuration options for MX Connect. This adds a ConnectParams model that can be passed in as an argument to GetWidget. The model is marshaled as JSON and sent as the body.