### PR TITLE
Add error handling to json.Unmarshal

### DIFF
--- a/client/account.go
+++ b/client/account.go
@@ -28,7 +28,9 @@ func (c *Client) ListAccounts(userGuid string) ([]*models.Account, error) {
 
 	if response.StatusCode == 200 {
 		accountsResponse := &models.AccountsResponse{}
-		json.Unmarshal([]byte(bufferStr), accountsResponse)
+		if err := json.Unmarshal([]byte(bufferStr), accountsResponse); err != nil {
+			return nil, err
+		}
 		return accountsResponse.Accounts, nil
 	}
 
@@ -53,7 +55,9 @@ func (c *Client) GetAccount(userGuid, accountGuid string) (*models.Account, erro
 
 	if response.StatusCode == 200 {
 		accountResponse := &models.AccountResponse{}
-		json.Unmarshal([]byte(bufferStr), accountResponse)
+		if err := json.Unmarshal([]byte(bufferStr), accountResponse); err != nil {
+			return nil, err
+		}
 		return accountResponse.Account, nil
 	}
 
@@ -86,7 +90,9 @@ func (c *Client) ListAccountTransactionsWithDateRange(userGuid, accountGuid, fro
 
 	if response.StatusCode == 200 {
 		transactionsResponse := &models.TransactionsResponse{}
-		json.Unmarshal([]byte(bufferStr), transactionsResponse)
+		if err := json.Unmarshal([]byte(bufferStr), transactionsResponse); err != nil {
+			return nil, err
+		}
 		return transactionsResponse.Transactions, nil
 	}
 

--- a/client/connect.go
+++ b/client/connect.go
@@ -19,7 +19,9 @@ func parseConnectResponse(response *http.Response) (*models.Connect, error) {
 
 	if response.StatusCode == 200 {
 		connectResponse := &models.ConnectResponse{}
-		json.Unmarshal([]byte(bufferStr), connectResponse)
+		if err := json.Unmarshal([]byte(bufferStr), connectResponse); err != nil {
+			return nil, err
+		}
 		return connectResponse.Connect, nil
 	}
 

--- a/client/credential.go
+++ b/client/credential.go
@@ -29,7 +29,9 @@ func (c *Client) ListCredentials(institutionCode string) ([]*models.Credential, 
 
 	if response.StatusCode == 200 {
 		credentialResponse := &models.CredentialsResponse{}
-		json.Unmarshal([]byte(bufferStr), credentialResponse)
+		if err := json.Unmarshal([]byte(bufferStr), credentialResponse); err != nil {
+			return nil, err
+		}
 		return credentialResponse.Credentials, nil
 	}
 

--- a/client/institution.go
+++ b/client/institution.go
@@ -19,7 +19,9 @@ func parseInstitutionResponse(response *http.Response) (*models.Institution, err
 
 	if response.StatusCode == 200 {
 		institutionResponse := &models.InstitutionResponse{}
-		json.Unmarshal([]byte(bufferStr), institutionResponse)
+		if err := json.Unmarshal([]byte(bufferStr), institutionResponse); err != nil {
+			return nil, err
+		}
 		return institutionResponse.Institution, nil
 	}
 
@@ -45,7 +47,9 @@ func (c *Client) ListInstitutions(name string) ([]*models.Institution, error) {
 
 	if response.StatusCode == 200 {
 		institutionResponse := &models.InstitutionsResponse{}
-		json.Unmarshal([]byte(bufferStr), institutionResponse)
+		if err := json.Unmarshal([]byte(bufferStr), institutionResponse); err != nil {
+			return nil, err
+		}
 		return institutionResponse.Institutions, nil
 	}
 

--- a/client/member.go
+++ b/client/member.go
@@ -19,7 +19,9 @@ func parseMembersResponse(response *http.Response) ([]*models.Member, error) {
 
 	if response.StatusCode == 200 {
 		membersResponse := &models.MembersResponse{}
-		json.Unmarshal([]byte(bufferStr), membersResponse)
+		if err := json.Unmarshal([]byte(bufferStr), membersResponse); err != nil {
+			return nil, err
+		}
 		return membersResponse.Members, nil
 	}
 
@@ -53,7 +55,9 @@ func parseMemberResponse(response *http.Response) (*models.Member, error) {
 
 	if response.StatusCode == 200 || response.StatusCode == 202 {
 		memberResponse := &models.MemberResponse{}
-		json.Unmarshal([]byte(bufferStr), memberResponse)
+		if err := json.Unmarshal([]byte(bufferStr), memberResponse); err != nil {
+			return nil, err
+		}
 		return memberResponse.Member, nil
 	}
 
@@ -108,7 +112,9 @@ func (c *Client) GetMemberChallenges(userGuid, memberGuid string) ([]*models.Cha
 
 	if response.StatusCode == 200 {
 		challengesResponse := &models.ChallengesResponse{}
-		json.Unmarshal([]byte(bufferStr), challengesResponse)
+		if err := json.Unmarshal([]byte(bufferStr), challengesResponse); err != nil {
+			return nil, err
+		}
 		return challengesResponse.Challenges, nil
 	}
 
@@ -250,7 +256,9 @@ func (c *Client) ListMemberAccounts(userGuid, memberGuid string) ([]*models.Acco
 
 	if response.StatusCode == 200 {
 		accountsResponse := &models.AccountsResponse{}
-		json.Unmarshal([]byte(bufferStr), accountsResponse)
+		if err := json.Unmarshal([]byte(bufferStr), accountsResponse); err != nil {
+			return nil, err
+		}
 		return accountsResponse.Accounts, nil
 	}
 
@@ -283,7 +291,9 @@ func (c *Client) ListMemberTransactionsWithDateRange(userGuid, memberGuid, fromD
 
 	if response.StatusCode == 200 {
 		transactionsResponse := &models.TransactionsResponse{}
-		json.Unmarshal([]byte(bufferStr), transactionsResponse)
+		if err := json.Unmarshal([]byte(bufferStr), transactionsResponse); err != nil {
+			return nil, err
+		}
 		return transactionsResponse.Transactions, nil
 	}
 
@@ -313,7 +323,9 @@ func (c *Client) ListMemberCredentials(userGuid, memberGuid string) ([]*models.C
 
 	if response.StatusCode == 200 {
 		credentialResponse := &models.CredentialsResponse{}
-		json.Unmarshal([]byte(bufferStr), credentialResponse)
+		if err := json.Unmarshal([]byte(bufferStr), credentialResponse); err != nil {
+			return nil, err
+		}
 		return credentialResponse.Credentials, nil
 	}
 

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -19,7 +19,9 @@ func parseTransactionResponse(response *http.Response) (*models.Transaction, err
 
 	if response.StatusCode == 200 {
 		transactionResponse := &models.TransactionResponse{}
-		json.Unmarshal([]byte(bufferStr), transactionResponse)
+		if err := json.Unmarshal([]byte(bufferStr), transactionResponse); err != nil {
+			return nil, err
+		}
 		return transactionResponse.Transaction, nil
 	}
 
@@ -52,7 +54,9 @@ func (c *Client) ListTransactionsWithDateRange(userGuid, fromDate, toDate string
 
 	if response.StatusCode == 200 {
 		transactionsResponse := &models.TransactionsResponse{}
-		json.Unmarshal([]byte(bufferStr), transactionsResponse)
+		if err := json.Unmarshal([]byte(bufferStr), transactionsResponse); err != nil {
+			return nil, err
+		}
 		return transactionsResponse.Transactions, nil
 	}
 

--- a/client/user.go
+++ b/client/user.go
@@ -19,7 +19,9 @@ func parseUserResponse(response *http.Response) (*models.User, error) {
 
 	if response.StatusCode == 200 {
 		userResponse := &models.UserResponse{}
-		json.Unmarshal([]byte(bufferStr), userResponse)
+		if err := json.Unmarshal([]byte(bufferStr), userResponse); err != nil {
+			return nil, err
+		}
 		return userResponse.User, nil
 	}
 
@@ -121,7 +123,9 @@ func (c *Client) ListUsers() ([]*models.User, error) {
 
 	if response.StatusCode == 200 {
 		userResponse := &models.UsersResponse{}
-		json.Unmarshal([]byte(bufferStr), userResponse)
+		if err := json.Unmarshal([]byte(bufferStr), userResponse); err != nil {
+			return nil, err
+		}
 		return userResponse.Users, nil
 	}
 


### PR DESCRIPTION
After reading @film42 's comment on https://github.com/mxenabled/atrium-go/pull/6, I noticed that we were not handling the error on any occurrence of `json.Unmarshal`. This PR adds error handling. 