### PR TITLE
Add 'ConnectionStatus' to member model + Allow IP binding

### DIFF
--- a/client/account.go
+++ b/client/account.go
@@ -12,7 +12,7 @@ func (c *Client) ListAccounts(userGuid string) ([]*models.Account, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (c *Client) GetAccount(userGuid, accountGuid string) (*models.Account, erro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts/" + accountGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *Client) ListAccountTransactionsWithDateRange(userGuid, accountGuid, fro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts/" + accountGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	ApiKey   string
 	ClientId string
 	ApiURL   string
+	LocalIP  *string
 }
 
 func (c *Client) defaultHeaders() *Headers {

--- a/client/connect.go
+++ b/client/connect.go
@@ -41,7 +41,7 @@ func (c *Client) GetWidgetWithConnectParams(userGuid string, params models.Conne
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/connect_widget_url"
-	response, err := Post(apiEndpointUrl, string(paramsJSON), c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, string(paramsJSON), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/credential.go
+++ b/client/credential.go
@@ -12,7 +12,7 @@ func (c *Client) ListCredentials(institutionCode string) ([]*models.Credential, 
 	}
 
 	apiEndpointUrl := c.ApiURL + "/institutions/" + institutionCode + "/credentials"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/http.go
+++ b/client/http.go
@@ -2,14 +2,16 @@ package client
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type Headers map[string]string
 
-func request(method, url string, body io.Reader, headers *Headers) (*http.Response, error) {
+func request(method, url string, body io.Reader, headers *Headers, localIP *string) (*http.Response, error) {
 	request, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
@@ -20,6 +22,30 @@ func request(method, url string, body io.Reader, headers *Headers) (*http.Respon
 	}
 
 	client := &http.Client{}
+
+	if localIP != nil {
+		localAddr, err := net.ResolveIPAddr("ip", *localIP)
+		if err != nil {
+			return nil, err
+		}
+
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			LocalAddr: &net.TCPAddr{
+				IP: localAddr.IP,
+			},
+		}
+
+		client = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				TLSHandshakeTimeout: 10 * time.Second,
+				Dial:                dialer.Dial,
+			},
+		}
+	}
+
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, err
@@ -28,20 +54,20 @@ func request(method, url string, body io.Reader, headers *Headers) (*http.Respon
 	return response, nil
 }
 
-func Get(url string, headers *Headers) (*http.Response, error) {
-	return request("GET", url, nil, headers)
+func Get(url string, headers *Headers, localIP *string) (*http.Response, error) {
+	return request("GET", url, nil, headers, localIP)
 }
 
-func Post(url, body string, headers *Headers) (*http.Response, error) {
-	return request("POST", url, strings.NewReader(body), headers)
+func Post(url, body string, headers *Headers, localIP *string) (*http.Response, error) {
+	return request("POST", url, strings.NewReader(body), headers, localIP)
 }
 
-func Put(url, body string, headers *Headers) (*http.Response, error) {
-	return request("PUT", url, strings.NewReader(body), headers)
+func Put(url, body string, headers *Headers, localIP *string) (*http.Response, error) {
+	return request("PUT", url, strings.NewReader(body), headers, localIP)
 }
 
-func Delete(url string, headers *Headers) (*http.Response, error) {
-	return request("DELETE", url, nil, headers)
+func Delete(url string, headers *Headers, localIP *string) (*http.Response, error) {
+	return request("DELETE", url, nil, headers, localIP)
 }
 
 func buildparams(name, fromDate, toDate string) string {

--- a/client/institution.go
+++ b/client/institution.go
@@ -28,7 +28,7 @@ func parseInstitutionResponse(response *http.Response) (*models.Institution, err
 
 func (c *Client) ListInstitutions(name string) ([]*models.Institution, error) {
 	apiEndpointUrl := c.ApiURL + "/institutions" + buildparams(name, "", "")
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetInstitution(code string) (*models.Institution, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/institutions/" + code
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/member.go
+++ b/client/member.go
@@ -32,7 +32,7 @@ func (c *Client) ListMembers(userGuid string) ([]*models.Member, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (c *Client) GetMember(userGuid, memberGuid string) (*models.Member, error) 
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (c *Client) GetMemberStatus(userGuid, memberGuid string) (*models.Member, e
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/status"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (c *Client) GetMemberChallenges(userGuid, memberGuid string) ([]*models.Cha
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/challenges"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (c *Client) CreateMember(userGuid string, member *models.Member, credential
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members"
-	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (c *Client) UpdateMember(userGuid string, member *models.Member, credential
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + member.Guid
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (c *Client) DeleteMember(userGuid string, memberGuid string) error {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid
-	response, err := Delete(apiEndpointUrl, c.defaultHeaders())
+	response, err := Delete(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	defer response.Body.Close()
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func (c *Client) AggregateMember(userGuid string, memberGuid string) (*models.Me
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/aggregate"
-	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, "", c.defaultHeaders(), c.LocalIP)
 	defer response.Body.Close()
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (c *Client) ResumeMember(userGuid, memberGuid string, challenges []*models.
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/resume"
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (c *Client) ListMemberAccounts(userGuid, memberGuid string) ([]*models.Acco
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/accounts"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (c *Client) ListMemberTransactionsWithDateRange(userGuid, memberGuid, fromD
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (c *Client) ListMemberCredentials(userGuid, memberGuid string) ([]*models.C
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/credentials"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -36,7 +36,7 @@ func (c *Client) ListTransactionsWithDateRange(userGuid, fromDate, toDate string
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (c *Client) GetTransaction(userGuid, transactionGuid string) (*models.Trans
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/transactions/" + transactionGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/client/user.go
+++ b/client/user.go
@@ -34,7 +34,7 @@ func (c *Client) CreateUser(user *models.User) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users"
-	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (c *Client) UpdateUser(user *models.User) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + user.Guid
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *Client) GetUser(userGuid string) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *Client) DeleteUser(userGuid string) error {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid
-	response, err := Delete(apiEndpointUrl, c.defaultHeaders())
+	response, err := Delete(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c *Client) DeleteUser(userGuid string) error {
 
 func (c *Client) ListUsers() ([]*models.User, error) {
 	apiEndpointUrl := c.ApiURL + "/users"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := Get(apiEndpointUrl, c.defaultHeaders(), c.LocalIP)
 	if err != nil {
 		return nil, err
 	}

--- a/models/member.go
+++ b/models/member.go
@@ -36,6 +36,7 @@ type Member struct {
 	Status                   string       `json:"status,omitempty"`
 	SuccessfullyAggregatedAt string       `json:"successfully_aggregated_at,omitempty"`
 	UserGuid                 string       `json:"user_guid,omitempty"`
+	ConnectionStatus         string       `json:"connection_status,omitempty"`
 }
 
 type MemberCreate struct {


### PR DESCRIPTION
1. MX docs show that 'Status' has been deprecated. This adds the 'ConnectionStatus' field to the member model.

2. Atrium MX, in production, works only by whitelisted IPs. This allows the caller to optionally specify which IP should the http client use.