### PR TITLE
Add http.Client to the client.Client struct

### DIFF
--- a/client/account.go
+++ b/client/account.go
@@ -12,7 +12,7 @@ func (c *Client) ListAccounts(userGuid string) ([]*models.Account, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (c *Client) GetAccount(userGuid, accountGuid string) (*models.Account, erro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts/" + accountGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *Client) ListAccountTransactionsWithDateRange(userGuid, accountGuid, fro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts/" + accountGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/account_number.go
+++ b/client/account_number.go
@@ -35,7 +35,7 @@ func (c *Client) ListAccountAccountNumbers(userGuid, accountGuid string) ([]*mod
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/accounts/" + accountGuid + "/account_numbers"
 
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (c *Client) ListMemberAccountNumbers(userGuid, memberGuid string) ([]*model
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/account_numbers"
 
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/account_number.go
+++ b/client/account_number.go
@@ -29,7 +29,7 @@ func parseAccountNumbersResponse(response *http.Response) ([]*models.AccountNumb
 }
 
 func (c *Client) ListAccountAccountNumbers(userGuid, accountGuid string) ([]*models.AccountNumber, error) {
-	if userGuid == "" || accountOrMemberGuid == "" {
+	if userGuid == "" || accountGuid == "" {
 		return nil, MissingGuid
 	}
 
@@ -45,7 +45,7 @@ func (c *Client) ListAccountAccountNumbers(userGuid, accountGuid string) ([]*mod
 }
 
 func (c *Client) ListMemberAccountNumbers(userGuid, memberGuid string) ([]*models.AccountNumber, error) {
-	if userGuid == "" || accountOrMemberGuid == "" {
+	if userGuid == "" || memberGuid == "" {
 		return nil, MissingGuid
 	}
 

--- a/client/account_owner.go
+++ b/client/account_owner.go
@@ -34,7 +34,7 @@ func (c *Client) ListMemberAccountOwners(userGuid, memberGuid string) ([]*models
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/account_owners"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"strconv"
+	"net/http"
 )
 
 var (
@@ -16,14 +17,16 @@ type Client struct {
 	ApiKey   string
 	ClientId string
 	ApiURL   string
+
+	HttpClient *http.Client
 }
 
-func (c *Client) defaultHeaders() *Headers {
+func (c *Client) defaultHeaders() Headers {
 	headers := Headers{}
 	headers["Content-Type"] = "application/json"
 	headers["MX-API-KEY"] = c.ApiKey
 	headers["MX-CLIENT-ID"] = c.ClientId
-	return &headers
+	return headers
 }
 
 func parseResponseErrors(statusCode int) error {

--- a/client/connect.go
+++ b/client/connect.go
@@ -43,7 +43,7 @@ func (c *Client) GetWidgetWithConnectParams(userGuid string, params models.Conne
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/connect_widget_url"
-	response, err := Post(apiEndpointUrl, string(paramsJSON), c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, string(paramsJSON), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/credential.go
+++ b/client/credential.go
@@ -12,7 +12,7 @@ func (c *Client) ListCredentials(institutionCode string) ([]*models.Credential, 
 	}
 
 	apiEndpointUrl := c.ApiURL + "/institutions/" + institutionCode + "/credentials"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/http.go
+++ b/client/http.go
@@ -9,18 +9,21 @@ import (
 
 type Headers map[string]string
 
-func request(method, url string, body io.Reader, headers *Headers) (*http.Response, error) {
+func (c *Client) request(method, url string, body io.Reader, headers Headers) (*http.Response, error) {
 	request, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}
 
-	for key, value := range *headers {
+	for key, value := range headers {
 		request.Header.Add(key, value)
 	}
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	// NOTE: This could be safer by adding a lock, but this will eventually memoize.
+	if c.HttpClient == nil {
+		c.HttpClient = &http.Client{}
+	}
+	response, err := c.HttpClient.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -28,20 +31,20 @@ func request(method, url string, body io.Reader, headers *Headers) (*http.Respon
 	return response, nil
 }
 
-func Get(url string, headers *Headers) (*http.Response, error) {
-	return request("GET", url, nil, headers)
+func (c *Client) Get(url string, headers Headers) (*http.Response, error) {
+	return c.request("GET", url, nil, headers)
 }
 
-func Post(url, body string, headers *Headers) (*http.Response, error) {
-	return request("POST", url, strings.NewReader(body), headers)
+func (c *Client) Post(url, body string, headers Headers) (*http.Response, error) {
+	return c.request("POST", url, strings.NewReader(body), headers)
 }
 
-func Put(url, body string, headers *Headers) (*http.Response, error) {
-	return request("PUT", url, strings.NewReader(body), headers)
+func (c *Client) Put(url, body string, headers Headers) (*http.Response, error) {
+	return c.request("PUT", url, strings.NewReader(body), headers)
 }
 
-func Delete(url string, headers *Headers) (*http.Response, error) {
-	return request("DELETE", url, nil, headers)
+func (c *Client) Delete(url string, headers Headers) (*http.Response, error) {
+	return c.request("DELETE", url, nil, headers)
 }
 
 func buildparams(name, fromDate, toDate string) string {

--- a/client/institution.go
+++ b/client/institution.go
@@ -30,7 +30,7 @@ func parseInstitutionResponse(response *http.Response) (*models.Institution, err
 
 func (c *Client) ListInstitutions(name string) ([]*models.Institution, error) {
 	apiEndpointUrl := c.ApiURL + "/institutions" + buildparams(name, "", "")
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (c *Client) GetInstitution(code string) (*models.Institution, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/institutions/" + code
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/member.go
+++ b/client/member.go
@@ -34,7 +34,7 @@ func (c *Client) ListMembers(userGuid string) ([]*models.Member, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *Client) GetMember(userGuid, memberGuid string) (*models.Member, error) 
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (c *Client) GetMemberStatus(userGuid, memberGuid string) (*models.Member, e
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/status"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (c *Client) GetMemberChallenges(userGuid, memberGuid string) ([]*models.Cha
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/challenges"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (c *Client) CreateMember(userGuid string, member *models.Member, credential
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members"
-	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (c *Client) UpdateMember(userGuid string, member *models.Member, credential
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + member.Guid
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := c.Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (c *Client) DeleteMember(userGuid string, memberGuid string) error {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid
-	response, err := Delete(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Delete(apiEndpointUrl, c.defaultHeaders())
 	defer response.Body.Close()
 	if err != nil {
 		return err
@@ -197,7 +197,7 @@ func (c *Client) AggregateMember(userGuid string, memberGuid string) (*models.Me
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/aggregate"
-	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, "", c.defaultHeaders())
 	defer response.Body.Close()
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (c *Client) ResumeMember(userGuid, memberGuid string, challenges []*models.
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/resume"
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := c.Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (c *Client) ListMemberAccounts(userGuid, memberGuid string) ([]*models.Acco
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/accounts"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (c *Client) ListMemberTransactionsWithDateRange(userGuid, memberGuid, fromD
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *Client) ListMemberCredentials(userGuid, memberGuid string) ([]*models.C
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/credentials"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (c *Client) VerifyMember(userGuid, memberGuid string) (*models.Member, erro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/verify"
-	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, "", c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (c *Client) IdentifyMember(userGuid, memberGuid string) (*models.Member, er
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/identify"
-	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, "", c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/member.go
+++ b/client/member.go
@@ -338,7 +338,7 @@ func (c *Client) VerifyMember(userGuid, memberGuid string) (*models.Member, erro
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/verify"
-	response, err := Post(apiEndpointUrl, c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (c *Client) IdentifyMember(userGuid, memberGuid string) (*models.Member, er
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/members/" + memberGuid + "/identify"
-	response, err := Post(apiEndpointUrl, c.defaultHeaders())
+	response, err := Post(apiEndpointUrl, "", c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -38,7 +38,7 @@ func (c *Client) ListTransactionsWithDateRange(userGuid, fromDate, toDate string
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/transactions" + buildparams("", fromDate, toDate)
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (c *Client) GetTransaction(userGuid, transactionGuid string) (*models.Trans
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid + "/transactions/" + transactionGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/client/user.go
+++ b/client/user.go
@@ -36,7 +36,7 @@ func (c *Client) CreateUser(user *models.User) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users"
-	response, err := Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := c.Post(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) UpdateUser(user *models.User) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + user.Guid
-	response, err := Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
+	response, err := c.Put(apiEndpointUrl, string(jsonStr), c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *Client) GetUser(userGuid string) (*models.User, error) {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Client) DeleteUser(userGuid string) error {
 	}
 
 	apiEndpointUrl := c.ApiURL + "/users/" + userGuid
-	response, err := Delete(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Delete(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (c *Client) DeleteUser(userGuid string) error {
 
 func (c *Client) ListUsers() ([]*models.User, error) {
 	apiEndpointUrl := c.ApiURL + "/users"
-	response, err := Get(apiEndpointUrl, c.defaultHeaders())
+	response, err := c.Get(apiEndpointUrl, c.defaultHeaders())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is an alternative solution to https://github.com/mxenabled/atrium-go/pull/8. This allows someone to insert their own custom `http.Client` into the mix. For example:

```go
localAddr, err := net.ResolveIPAddr("ip", localIP)
if err != nil {
	return nil, err
}
dialer := &net.Dialer{
	Timeout:   30 * time.Second,
	KeepAlive: 30 * time.Second,
	LocalAddr: &net.TCPAddr{
		IP: localAddr.IP,
	},
}
httpClient = &http.Client{
	Transport: &http.Transport{
		Proxy:               http.ProxyFromEnvironment,
		TLSHandshakeTimeout: 10 * time.Second,
		Dial:                dialer.Dial,
	},
}

// ... and then finally ...

atriumClient := &client.Client{
	ApiKey: "1234",
	ClientId: "1234",
	HttpClient: httpClient
}
```
And everything works just fine!

NOTE: This currently includes changes introduced in https://github.com/mxenabled/atrium-go/pull/9 as well.

cc @brettmortensen 