### PR TITLE
Add os package

### DIFF
--- a/api_statements.go
+++ b/api_statements.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 

--- a/configuration.go
+++ b/configuration.go
@@ -61,7 +61,7 @@ func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		BasePath:      "https://vestibule.mx.com",
 		DefaultHeader: make(map[string]string),
-		UserAgent:     "MX-Codegen/2.5.0/go",
+		UserAgent:     "MX-Codegen/2.5.1/go",
 	}
 	return cfg
 }


### PR DESCRIPTION
`go build` was failing because the os package was not imported.

@minond @film42 